### PR TITLE
 Add single-argument overload for `LoadMapInput`

### DIFF
--- a/Assets/__Scripts/Loading/MapLoader.cs
+++ b/Assets/__Scripts/Loading/MapLoader.cs
@@ -678,6 +678,10 @@ public class MapLoader : MonoBehaviour
 #endif
     }
 
+    public void LoadMapInput(string input)
+    {
+        LoadMapInput(input, false);
+    }
 
     public void LoadMapInput(string input, bool forceReplay = false)
     {

--- a/Assets/__Scripts/Loading/MapLoader.cs
+++ b/Assets/__Scripts/Loading/MapLoader.cs
@@ -678,10 +678,6 @@ public class MapLoader : MonoBehaviour
 #endif
     }
 
-    public void LoadMapInput(string input)
-    {
-        LoadMapInput(input, false);
-    }
 
     public void LoadMapInput(string input, bool forceReplay = false)
     {
@@ -768,6 +764,18 @@ public class MapLoader : MonoBehaviour
         UrlArgHandler.LoadedMapURL = null;
         LoadMapDirectory(input);
 #endif
+    }
+
+
+    /// <summary>
+    /// Single-argument overload for <see cref="LoadMapInput(string, bool)"/>.
+    /// <br></br>
+    /// This is intended for using with <c>SendMessage(...)</c> because that method only allows one parameter to be passed.
+    /// </summary>
+    /// <param name="input">Map URL or BeatSaver ID</param>
+    public void LoadMapInput(string input)
+    {
+        LoadMapInput(input, false);
     }
 
 


### PR DESCRIPTION
I was getting annoyed with BeatSaver initializing a new ArcViewer frame every time I want to preview a map (and be stuck loading for 5+ seconds), so I thought "surely there must be a way to reuse one instance". As it turns out, you are able to call `gameInstance.SendMessage` from the browser window context to execute C# methods on GameObjects. `SendMessage` however only allows for one parameter.
Apparently the existing `LoadMapInput` variant with the optional `bool` isn't compiled in the same way an overload would be and always takes 2 parameters in the assembly, so a change like this would be necessary for my desired interop.

With this patch you can use 
```javascript
gameInstance.SendMessage('Preview', 'LoadMapInput', '849a') // or any other map ID / URL
```
to set the map. This also works with `<iframe>`s as long as ArcViewer is hosted on the same origin.